### PR TITLE
Fix errors when num or chr type contain value > .Machine$integer.max

### DIFF
--- a/R/hablar.R
+++ b/R/hablar.R
@@ -73,7 +73,7 @@ could_chr_be_int <- function(.x) {
   if(all(is.na(.x)) | length(.x) == 0) {
     return(FALSE)}
   .x <- as.numeric(.x)
-  if(all(is.na(.x)) | length(.x) == 0) {
+  if(all(is.na(.x)) | length(.x) == 0 | any(.x > .Machine$integer.max)) {
     return(FALSE)}
   ifelse(all(.x[!is.na(.x)] == as.integer(.x[!is.na(.x)])), TRUE, FALSE)
 }
@@ -83,7 +83,7 @@ could_chr_be_int <- function(.x) {
 could_num_be_int <- function(.x) {
   if(!is.numeric(.x)) {
     stop("Only works with numeric vectors")}
-  if(all(is.na(.x)) | length(.x) == 0 | any(is.nan(.x) | any(is.infinite(.x)))) {
+  if(all(is.na(.x)) | length(.x) == 0 | any(is.nan(.x) | any(is.infinite(.x))) | any(.x > .Machine$integer.max)) {
     return(FALSE)}
   ifelse(all(.x[!is.na(.x)] == as.integer(.x[!is.na(.x)])), TRUE, FALSE)
 }

--- a/R/hablar.R
+++ b/R/hablar.R
@@ -106,8 +106,8 @@ could_dtm_be_dte <- function(.x) {
     stop("Only works with date-time vectors (POSIXct)")}
   if(all(is.na(.x)) | length(.x) == 0) {
     return(FALSE)}
-  .timestamps <- strftime(.x, format="%H:%M:%S")
-  ifelse(length(unique(.timestamps[!is.na(.timestamps)])) == 1, TRUE, FALSE)
+  lossy = .x != as.Date(.x)
+  ifelse(any(lossy[!is.na(lossy)]), FALSE, TRUE)
 }
 
 

--- a/R/hablar.R
+++ b/R/hablar.R
@@ -73,7 +73,7 @@ could_chr_be_int <- function(.x) {
   if(all(is.na(.x)) | length(.x) == 0) {
     return(FALSE)}
   .x <- as.numeric(.x)
-  if(all(is.na(.x)) | length(.x) == 0 | any(.x > .Machine$integer.max)) {
+  if(all(is.na(.x)) | length(.x) == 0 | any(.x > .Machine$integer.max, na.rm=T)) {
     return(FALSE)}
   ifelse(all(.x[!is.na(.x)] == as.integer(.x[!is.na(.x)])), TRUE, FALSE)
 }
@@ -83,7 +83,7 @@ could_chr_be_int <- function(.x) {
 could_num_be_int <- function(.x) {
   if(!is.numeric(.x)) {
     stop("Only works with numeric vectors")}
-  if(all(is.na(.x)) | length(.x) == 0 | any(is.nan(.x) | any(is.infinite(.x))) | any(.x > .Machine$integer.max)) {
+  if(all(is.na(.x)) | length(.x) == 0 | any(is.nan(.x) | any(is.infinite(.x))) | any(.x > .Machine$integer.max, na.rm=T)) {
     return(FALSE)}
   ifelse(all(.x[!is.na(.x)] == as.integer(.x[!is.na(.x)])), TRUE, FALSE)
 }


### PR DESCRIPTION
Fixes error raised on retype(20211031212817) or retype("20211031212817").  Errors in could_num_be_int and could_chr_be_int.

If distinction between an int as an R class and an integer as a concept should implement an alternate function such as could_num_be_integer.

fixes #6 
fixes #7 
fixes #8 