### PR TITLE
Remove overly strict test

### DIFF
--- a/tests/testthat/test.ifs.R
+++ b/tests/testthat/test.ifs.R
@@ -50,9 +50,6 @@ test_that("if_else_", {
                as.Date(c("2019-01-01", NA, NA)) 
   )
 
-  expect_error(if_else_(c(T, F, NA),
-                        1,
-                        1L))
   expect_warning(if_else_(c(T, F, NA),
                         as.factor(1),
                         factor(1, levels = c("1", "2"))))


### PR DESCRIPTION
This PR makes your package compatible with the next version of dplyr:

`if_else()` now uses vctrs, which generally makes it more permissive when there are varying types. In particular, it no longer fails when `1` and `1L` are mixed, but you have a test checking for this. I've removed the test since this is really checking dplyr behavior, not any behavior you added here.

You might not even really need this `if_else_()` function of yours anymore.

We plan to submit dplyr 1.1.0 on January 27th.

This should be compatible with both dev and CRAN dplyr. It would help us out if you could go ahead and send a patch version of your package in ahead of time! Thanks!